### PR TITLE
fix: corrige vulnerabilidades de dependências (auditoria supply chain)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "cryptography>=50.0.0",
     "defusedxml>=0.7.1",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
+    "mcp>=1.28.1",
     "pydantic>=2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "defusedxml>=0.7.1",
     "fastmcp>=3.2.0",
     "httpx>=0.27.0",
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2.0",
     "pydantic>=2.0",
 ]
 


### PR DESCRIPTION
## Auditoria de supply chain (2026-08-22)

Atualização de dependências vulneráveis identificadas por `npm audit` / `pnpm audit` / `pip-audit`. Escopo mínimo: só arquivos de dependência e o estritamente necessário para build/testes.

### Pacotes alterados
- cryptography: transitivo (não declarado antes) -> direto >=50.0.0, resolvido 50.0.0
- mcp: transitivo (não declarado antes) -> direto >=1.28.1, resolvido 1.29.0

### Gates executados
- **lint**: OK - uv run ruff check . -> All checks passed!; uv run ruff format --check . -> 26 files already formatted
- **typecheck**: PARCIAL, não bloqueante - uv run mypy src encontrou 4 erros pré-existentes, nenhum relacionado a cryptography/mcp: rss_agro.py:16 (unused type:ignore), open_meteo.py:42 (arg-type no httpx.Client.get), comex_stat.py:127 e cotacao.py:47 (no-any-return). mypy NÃO faz parte do gate de CI do projeto (.github/workflows só roda ruff check, ruff format --check e pytest) - não tentei corrigir por serem err
- **tests**: OK - uv run pytest -> 149 passed in 1.24s (8 arquivos de teste, 0 falhas, 0 skips)
- **build**: OK - uv build -> sdist e wheel construídos com sucesso, versão do pacote permaneceu 0.4.0 (sem bump, conforme pedido); dist/ removido após validação (está no .gitignore)
- **audit_final**: OK - uvx pip-audit --no-deps -r <export uv sem -e .> -> No known vulnerabilities found (89 pacotes resolvidos, export via 'uv export --no-hashes --no-emit-project --extra dev')

### O que ficou de fora e por quê
Os 4 erros de mypy (typecheck) ficaram de fora da correção: são pré-existentes no código (httpx/pydantic com tipagem estrita), não têm relação com cryptography ou mcp, e mypy não é gate de CI deste repo (só ruff+pytest). Nada mais pendente: lint, testes, build e a auditoria final de supply chain (pip-audit) estão todos limpos.

### Riscos e observações
uv.lock é gitignored neste repo (nunca foi versionado), então o lock foi gerado do zero nesta rodada, não é um upgrade incremental de um lock existente - por isso todas as 89 dependências foram resolvidas nas versões mais recentes compatíveis (ex: httpx subiu de facto para 0.28.1, fastmcp para 3.4.7), não só cryptography/mcp. Isso é esperado dado que o projeto não versiona lock file; os 149 testes e o build passaram normalmente com esse conjunto. cryptography e mcp não eram dependências diretas antes (eram transitivas via fastmcp/authlib/joserfc/pyjwt); a tarefa pedia para declará-las diretamente com o piso de versão >=50.0.0 e >=1.28.1, o que foi feito. git fetch origin deu timeout (exit 124) após 40s - segui com a branch main local como base, conforme instruído. Nenhum push foi feito. Working tree do worktree está limpo após o commit (git status --porcelain vazio).
