### PR TITLE
[codex] Integra APIs oficiais AgroAPI da Embrapa

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,11 @@ Também são aceitos os nomes oficiais `AGROAPI_CONSUMER_KEY` e
 `AGROAPI_CONSUMER_SECRET`. Para desenvolvimento, um token já emitido pode ser
 fornecido em `AGROAPI_TOKEN` ou `AGROAPI_ACCESS_TOKEN`.
 
-Não salve credenciais no repositório. O cliente usa OAuth 2.0
-`client_credentials`, mantém o token somente em memória e o renova uma vez após
-uma resposta HTTP 401.
+Não salve credenciais no repositório. Com `AGROAPI_CLIENT_ID` e
+`AGROAPI_CLIENT_SECRET`, o cliente usa OAuth 2.0 `client_credentials`, mantém o
+token somente em memória e tenta renová-lo uma vez após uma resposta HTTP 401.
+Tokens fornecidos por `AGROAPI_TOKEN` ou `AGROAPI_ACCESS_TOKEN` são estáticos,
+não são renovados automaticamente e devem ser substituídos manualmente.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-agro-brasil
 
-MCP server de dados do agronegócio brasileiro: cotações de boi gordo, soja, milho e leite, calendário de safra (CONAB), previsão do tempo, câmbio PTAX, exportações agro e notícias do setor.
+MCP server de dados do agronegócio brasileiro: cotações de boi gordo, soja, milho e leite, calendário de safra (CONAB), previsão do tempo, câmbio PTAX, exportações agro, notícias do setor e integração opcional com as APIs oficiais AgroAPI/Embrapa.
 
 Parte da família [MCP Brasil](https://github.com/DeHor-Labs) junto com
 [mcp-fiscal-brasil](https://github.com/DeHor-Labs/mcp-fiscal-brasil) e
@@ -29,6 +29,7 @@ do agronegócio brasileiro em tempo quase real:
 - **Notícias** - últimas manchetes do agronegócio via RSS (Canal Rural), com filtro por tema
 - **Calendário de safra** - janelas de plantio e colheita por cultura e região, curado do CONAB
 - **Futuros B3** - informação sobre contratos BGI, CCM, SFI, ICF (fonte paga; alternativas indicadas)
+- **AgroAPI/Embrapa (opcional)** - AGROFIT, ZARC e cultivares Agritec, Bioinsumos e AgroTermos
 - **Conversões** - arroba, saca, hectare, alqueire e outras unidades do agro
 
 Os dados de cotação são obtidos por scraping de páginas públicas com cache local. Clima e câmbio usam APIs JSON abertas e gratuitas.
@@ -89,6 +90,37 @@ Ou adicione ao `.claude/settings.json` do projeto:
 }
 ```
 
+### AgroAPI/Embrapa (opcional)
+
+As APIs AGROFIT v1, Agritec v2, Bioinsumos v2 e AgroTermos v1 exigem cadastro,
+criação de aplicação e assinatura no [portal AgroAPI da Embrapa](https://www.portal.agroapi.cnptia.embrapa.br/).
+Sem credenciais, o servidor inicia normalmente e as tools AgroAPI não são registradas.
+
+Configure o par de credenciais da aplicação:
+
+```json
+{
+  "mcpServers": {
+    "agro-brasil": {
+      "command": "uvx",
+      "args": ["mcp-agro-brasil"],
+      "env": {
+        "AGROAPI_CLIENT_ID": "CONSUMER_KEY_DA_APLICACAO",
+        "AGROAPI_CLIENT_SECRET": "CONSUMER_SECRET_DA_APLICACAO"
+      }
+    }
+  }
+}
+```
+
+Também são aceitos os nomes oficiais `AGROAPI_CONSUMER_KEY` e
+`AGROAPI_CONSUMER_SECRET`. Para desenvolvimento, um token já emitido pode ser
+fornecido em `AGROAPI_TOKEN` ou `AGROAPI_ACCESS_TOKEN`.
+
+Não salve credenciais no repositório. O cliente usa OAuth 2.0
+`client_credentials`, mantém o token somente em memória e o renova uma vez após
+uma resposta HTTP 401.
+
 ---
 
 ## Ferramentas disponíveis
@@ -110,6 +142,25 @@ Ou adicione ao `.claude/settings.json` do projeto:
 | `listar_pracas` | Lista praças disponíveis no provider Scot | - |
 | `listar_produtos` | Lista todos os produtos com cotação disponível | - |
 | `listar_unidades` | Lista unidades suportadas pelo conversor | - |
+
+### Ferramentas AgroAPI opcionais
+
+Estas tools aparecem somente quando a autenticação AgroAPI está configurada:
+
+| Ferramenta | Descrição | Parâmetros principais |
+|------------|-----------|-----------------------|
+| `agrofit_buscar_produtos` | Busca registros de defensivos e produtos fitossanitários | `termo`, `cultura`, `praga`, `ingrediente_ativo`, `categoria`, `produto_biologico`, `pagina` |
+| `agrofit_consultar_produto` | Consulta produto AGROFIT por registro MAPA | `numero_registro` |
+| `agritec_buscar_municipios` | Resolve município para código IBGE | `nome`, `uf` |
+| `agritec_buscar_culturas` | Resolve cultura para ID Agritec | `nome` |
+| `agritec_consultar_zarc` | Consulta o ZARC oficial por município e cultura | `codigo_ibge`, `id_cultura`, `risco` |
+| `agritec_buscar_cultivares` | Busca cultivares por cultura, UF e safra | `id_cultura`, `uf`, `safra`, `regiao`, `grupo`, `cultivar` |
+| `bioinsumos_buscar_produtos` | Busca produtos biológicos ou inoculantes | `tipo`, `termo`, `cultura`, `praga`, `ingrediente_ativo`, `uf`, `especie`, `pagina` |
+| `agrotermos_buscar` | Busca conceitos por fragmento; relações exigem termo exato | `termo`, `incluir_relacoes` |
+
+As respostas de AGROFIT e Bioinsumos são informativas. Elas não constituem
+prescrição agronômica; confirme registro vigente, cultura, alvo, rótulo/bula,
+receituário e orientação de profissional habilitado antes do uso.
 
 ### Exemplos de retorno
 
@@ -174,6 +225,7 @@ RS, SC, PR, SP, MG, GO, BA, RJ, ES e Brasil (média nacional).
 - **Banco Central do Brasil (PTAX)** - câmbio USD/BRL: [olinda.bcb.gov.br](https://olinda.bcb.gov.br/) (API aberta, sem token)
 - **Comex Stat / MDIC** - exportações do agronegócio: [comexstat.mdic.gov.br](https://comexstat.mdic.gov.br/) (API aberta, sem token)
 - **Canal Rural** - notícias do agronegócio: [canalrural.com.br](https://www.canalrural.com.br/) (RSS público)
+- **AgroAPI / Embrapa Agricultura Digital** - AGROFIT, Agritec, Bioinsumos e AgroTermos: [portal.agroapi.cnptia.embrapa.br](https://www.portal.agroapi.cnptia.embrapa.br/)
 
 ---
 
@@ -204,6 +256,7 @@ O scraping respeita as fontes: cache local de 15 minutos, sem sobrecarga de requ
 - [x] Câmbio USD/BRL PTAX via Banco Central do Brasil
 - [x] Exportações do agronegócio via Comex Stat / MDIC (soja, carne bovina, milho)
 - [x] Notícias do agronegócio via RSS (Canal Rural)
+- [x] Integração opcional AgroAPI/Embrapa: AGROFIT, Agritec v2, Bioinsumos v2 e AgroTermos
 
 **Onda 3 - Safra e Mercado Futuro**
 - [x] Calendário de safra via CONAB (soja, milho 1a/2a, feijão, café, sorgo, algodão - 5 regiões)
@@ -211,6 +264,7 @@ O scraping respeita as fontes: cache local de 15 minutos, sem sobrecarga de requ
 
 **Próximos**
 - [ ] Integrar futuros B3 quando fonte gratuita ou open-access estiver disponível
+- [ ] Avaliar ClimAPI, SATVeg e SmartSolos após validação de contratos e planos
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -12,10 +12,12 @@ para assistentes de IA (Claude, etc.). Segue a mesma família de design de
 src/mcp_agro_brasil/
 ├── providers/       # fontes de dados (scraping, APIs)
 │   ├── scot.py      # Scot Consultoria - cotação regional boi gordo (HTML)
-│   └── esalq.py     # ESALQ/B3 via Notícias Agrícolas - indicador nacional
+│   ├── esalq.py     # ESALQ/B3 via Notícias Agrícolas - indicador nacional
+│   └── agroapi.py   # OAuth e consultas AgroAPI/Embrapa
 ├── core/            # lógica de negócio independente de interface
 │   ├── cotacao.py   # orquestração: primário Scot -> fallback ESALQ, cache
 │   └── conversao.py # conversões puras de unidades (sem rede)
+├── agroapi_tools.py # tools autenticadas registradas condicionalmente
 └── server.py        # tools FastMCP que expõem o core via MCP
 ```
 
@@ -48,6 +50,21 @@ src/mcp_agro_brasil/
 - Unidade canônica intermediária: `kg` (peso) e `m²` (área).
 - Conversão cruzada peso-área é proibida e levanta `ValueError`.
 
+### AgroAPI/Embrapa
+
+- Integração opcional: sem token ou par completo de credenciais, nenhuma tool
+  AgroAPI é registrada e o conjunto padrão permanece inalterado.
+- OAuth 2.0 `client_credentials`: Consumer Key/Secret obtêm um Bearer token em
+  `https://api.cnptia.embrapa.br/token`.
+- O token fica apenas em memória, respeita `expires_in` com margem de segurança
+  e é renovado uma única vez após HTTP 401.
+- As bases são fixas e versionadas: AGROFIT v1, Agritec v2, Bioinsumos v2 e
+  AgroTermos v1. URLs não são controladas por entrada do usuário.
+- As buscas AGROFIT/Bioinsumos removem documentos extensos do resultado resumido;
+  a consulta individual preserva o detalhe oficial.
+- Testes usam mocks e exemplos dos OpenAPIs oficiais. Testes de contrato reais
+  dependem de uma aplicação assinante e não fazem parte da suíte padrão.
+
 ## Extensibilidade
 
 Para adicionar soja/milho/café/leite:
@@ -68,5 +85,7 @@ Para conectar ao AgroVoz:
 | HTTP client | `httpx` | consistência com mcp-fiscal e mcp-juridico |
 | Parsing | `re` (regex) | HTML simples, sem necessidade de BeautifulSoup |
 | Cache | dict em memória | MVP; suficiente para sessão single-process |
+| OAuth AgroAPI | token em memória + renovação em 401 | evita persistir ou registrar segredos |
+| Registro AgroAPI | condicional por ambiente | integração opcional sem afetar tools abertas |
 | Build | hatchling | consistência com família MCP Brasil |
 | Testes | pytest + fixtures HTML | evita dependência de rede nos testes |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-agro-brasil"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP de dados do agronegócio brasileiro - cotações, calendário de safra, câmbio, clima, exportações e indicadores de mercado."
 authors = [
     { name = "Nikolas de Hor", email = "nikolasdehor79@gmail.com" }

--- a/src/mcp_agro_brasil/__init__.py
+++ b/src/mcp_agro_brasil/__init__.py
@@ -1,3 +1,3 @@
 """MCP Agro Brasil - dados do agronegócio brasileiro via Model Context Protocol."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/mcp_agro_brasil/agroapi_tools.py
+++ b/src/mcp_agro_brasil/agroapi_tools.py
@@ -1,0 +1,188 @@
+"""Registro opcional das tools AgroAPI/Embrapa no servidor FastMCP."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_agro_brasil.providers import agroapi
+
+
+def agrofit_buscar_produtos(
+    termo: str = "",
+    cultura: str = "",
+    praga: str = "",
+    ingrediente_ativo: str = "",
+    categoria: str = "",
+    produto_biologico: bool | None = None,
+    pagina: int = 1,
+) -> dict[str, Any]:
+    """Busca defensivos e produtos fitossanitários registrados no AGROFIT/MAPA.
+
+    Informe ao menos um filtro. Esta é uma consulta informativa a registros
+    oficiais, não uma prescrição agronômica.
+
+    Args:
+        termo: Busca textual geral, como "mosca branca".
+        cultura: Cultura agrícola, como "Soja" ou "Algodão".
+        praga: Nome comum da praga ou doença.
+        ingrediente_ativo: Ingrediente ativo do produto.
+        categoria: Classe/categoria agronômica exata.
+        produto_biologico: Filtra produtos de origem biológica quando informado.
+        pagina: Página da API, começando em 1.
+    """
+    return agroapi.buscar_produtos_agrofit(
+        termo=termo,
+        cultura=cultura,
+        praga=praga,
+        ingrediente_ativo=ingrediente_ativo,
+        categoria=categoria,
+        produto_biologico=produto_biologico,
+        pagina=pagina,
+    )
+
+
+def agrofit_consultar_produto(numero_registro: str) -> dict[str, Any]:
+    """Consulta detalhes de um produto AGROFIT pelo número de registro no MAPA.
+
+    Args:
+        numero_registro: Número oficial de registro do produto formulado.
+    """
+    return agroapi.consultar_produto_agrofit(numero_registro)
+
+
+def agritec_buscar_municipios(nome: str, uf: str) -> dict[str, Any]:
+    """Resolve nome e UF de município para o código IBGE exigido pela Agritec.
+
+    Use antes de ``agritec_consultar_zarc`` quando o código IBGE não for conhecido.
+
+    Args:
+        nome: Nome ou trecho do nome do município.
+        uf: Sigla da unidade federativa, como "MT" ou "GO".
+    """
+    return agroapi.buscar_municipios_agritec(nome, uf)
+
+
+def agritec_buscar_culturas(nome: str) -> dict[str, Any]:
+    """Resolve nome de cultura para o identificador exigido pela Agritec.
+
+    Use antes das consultas de ZARC ou cultivares quando o ID não for conhecido.
+
+    Args:
+        nome: Nome ou trecho do nome da cultura, como "soja" ou "milho".
+    """
+    return agroapi.buscar_culturas_agritec(nome)
+
+
+def agritec_consultar_zarc(
+    codigo_ibge: int,
+    id_cultura: int,
+    risco: str = "todos",
+) -> dict[str, Any]:
+    """Consulta o Zoneamento Agrícola de Risco Climático oficial na Agritec.
+
+    Args:
+        codigo_ibge: Código IBGE do município; resolva com agritec_buscar_municipios.
+        id_cultura: ID da cultura; resolva com agritec_buscar_culturas.
+        risco: Nível de risco: "20", "30", "40" ou "todos".
+    """
+    return agroapi.consultar_zarc_agritec(codigo_ibge, id_cultura, risco)
+
+
+def agritec_buscar_cultivares(
+    id_cultura: int,
+    uf: str,
+    safra: str = "2026-2027",
+    regiao: str = "",
+    grupo: str = "",
+    cultivar: str = "",
+) -> dict[str, Any]:
+    """Busca cultivares indicadas pela Agritec para cultura, UF e safra.
+
+    Args:
+        id_cultura: ID da cultura; resolva com agritec_buscar_culturas.
+        uf: Sigla da unidade federativa.
+        safra: Safra no formato YYYY-YYYY. Padrão: "2026-2027".
+        regiao: Região Agritec opcional, de "1" a "5".
+        grupo: Grupo opcional: I, II, III ou IV.
+        cultivar: Trecho opcional do nome da cultivar.
+    """
+    return agroapi.buscar_cultivares_agritec(
+        id_cultura=id_cultura,
+        uf=uf,
+        safra=safra,
+        regiao=regiao,
+        grupo=grupo,
+        cultivar=cultivar,
+    )
+
+
+def bioinsumos_buscar_produtos(
+    tipo: str = "biologico",
+    termo: str = "",
+    cultura: str = "",
+    praga: str = "",
+    ingrediente_ativo: str = "",
+    uf: str = "",
+    especie: str = "",
+    pagina: int = 1,
+) -> dict[str, Any]:
+    """Busca produtos biológicos ou inoculantes registrados no MAPA.
+
+    Informe ao menos um filtro. Para ``tipo="biologico"``, use praga e
+    ingrediente_ativo. Para ``tipo="inoculante"``, use UF e espécie.
+
+    Args:
+        tipo: "biologico" ou "inoculante".
+        termo: Busca textual geral.
+        cultura: Cultura agrícola.
+        praga: Nome comum da praga; exclusivo de produtos biológicos.
+        ingrediente_ativo: Ingrediente; exclusivo de produtos biológicos.
+        uf: UF do titular; exclusiva de inoculantes.
+        especie: Espécie do microrganismo; exclusiva de inoculantes.
+        pagina: Página da API, começando em 1.
+    """
+    return agroapi.buscar_produtos_bioinsumos(
+        tipo=tipo,
+        termo=termo,
+        cultura=cultura,
+        praga=praga,
+        ingrediente_ativo=ingrediente_ativo,
+        uf=uf,
+        especie=especie,
+        pagina=pagina,
+    )
+
+
+def agrotermos_buscar(termo: str, incluir_relacoes: bool = False) -> dict[str, Any]:
+    """Busca termos, conceitos e relações no vocabulário AgroTermos da Embrapa.
+
+    A busca comum aceita fragmentos. Para incluir relações semânticas, informe
+    o nome completo e exato do termo ou conceito.
+
+    Args:
+        termo: Fragmento; ou termo exato quando incluir_relacoes for verdadeiro.
+        incluir_relacoes: Consulta relações de um termo exato quando verdadeiro.
+    """
+    return agroapi.buscar_termos_agrotermos(termo, incluir_relacoes)
+
+
+_TOOLS = (
+    agrofit_buscar_produtos,
+    agrofit_consultar_produto,
+    agritec_buscar_municipios,
+    agritec_buscar_culturas,
+    agritec_consultar_zarc,
+    agritec_buscar_cultivares,
+    bioinsumos_buscar_produtos,
+    agrotermos_buscar,
+)
+
+
+def registrar_tools_agroapi(app: Any, *, enabled: bool | None = None) -> bool:
+    """Registra o bloco AgroAPI somente quando há configuração completa."""
+    should_enable = agroapi.is_configured() if enabled is None else enabled
+    if not should_enable:
+        return False
+    for tool in _TOOLS:
+        app.tool(tool)
+    return True

--- a/src/mcp_agro_brasil/providers/agroapi.py
+++ b/src/mcp_agro_brasil/providers/agroapi.py
@@ -483,7 +483,7 @@ def buscar_culturas_agritec(
 def consultar_zarc_agritec(
     codigo_ibge: int,
     id_cultura: int,
-    risco: str = "20",
+    risco: str = "todos",
     *,
     client: AgroApiTransport | None = None,
 ) -> dict[str, Any]:

--- a/src/mcp_agro_brasil/providers/agroapi.py
+++ b/src/mcp_agro_brasil/providers/agroapi.py
@@ -1,0 +1,641 @@
+"""Cliente e consultas para as APIs oficiais AgroAPI da Embrapa.
+
+As APIs usam OAuth 2.0 no fluxo ``client_credentials``. A integração é opcional
+e lê as credenciais apenas das variáveis de ambiente ``AGROAPI_CLIENT_ID`` e
+``AGROAPI_CLIENT_SECRET``. Também é possível fornecer um token já emitido em
+``AGROAPI_TOKEN``.
+
+Documentação oficial: https://www.portal.agroapi.cnptia.embrapa.br/
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+import unicodedata
+from dataclasses import dataclass
+from datetime import date
+from threading import Lock
+from typing import Any, Literal, Protocol
+from urllib.parse import quote
+
+import httpx
+
+ApiName = Literal["agrofit", "agritec", "bioinsumos", "agrotermos"]
+ParamValue = str | int | bool
+
+_TOKEN_URL = "https://api.cnptia.embrapa.br/token"
+_API_BASE_URLS: dict[ApiName, str] = {
+    "agrofit": "https://api.cnptia.embrapa.br/agrofit/v1",
+    "agritec": "https://api.cnptia.embrapa.br/agritec/v2",
+    "bioinsumos": "https://api.cnptia.embrapa.br/bioinsumos/v2",
+    "agrotermos": "https://api.cnptia.embrapa.br/agrotermos/v1",
+}
+_API_LABELS: dict[ApiName, str] = {
+    "agrofit": "AGROFIT v1",
+    "agritec": "Agritec v2",
+    "bioinsumos": "Bioinsumos v2",
+    "agrotermos": "AgroTermos v1",
+}
+_DOC_URLS: dict[ApiName, str] = {
+    "agrofit": "https://www.portal.agroapi.cnptia.embrapa.br/api-docs/agrofit",
+    "agritec": "https://www.portal.agroapi.cnptia.embrapa.br/api-docs/agritec",
+    "bioinsumos": "https://www.portal.agroapi.cnptia.embrapa.br/api-docs/bioinsumos",
+    "agrotermos": "https://www.portal.agroapi.cnptia.embrapa.br/api-docs/agrotermos",
+}
+_TIMEOUT = 20.0
+_TOKEN_EXPIRY_MARGIN_SECONDS = 30
+
+_AGROFIT_AVISO = (
+    "Consulta informativa a registros oficiais. O resultado não constitui prescrição agronômica. "
+    "Confirme registro vigente, cultura, alvo, bula e receituário com profissional habilitado."
+)
+_BIOINSUMOS_AVISO = (
+    "Consulta informativa a registros oficiais. Confirme registro vigente, indicação de uso, "
+    "rótulo/bula e orientação de profissional habilitado antes da aplicação."
+)
+_ZARC_AVISO = (
+    "O ZARC informa janelas oficiais de menor risco climático; não garante produtividade, "
+    "seguro ou crédito e não substitui assistência técnica."
+)
+_UFS = {
+    "AC",
+    "AL",
+    "AP",
+    "AM",
+    "BA",
+    "CE",
+    "DF",
+    "ES",
+    "GO",
+    "MA",
+    "MT",
+    "MS",
+    "MG",
+    "PA",
+    "PB",
+    "PR",
+    "PE",
+    "PI",
+    "RJ",
+    "RN",
+    "RS",
+    "RO",
+    "RR",
+    "SC",
+    "SP",
+    "SE",
+    "TO",
+}
+
+
+class AgroApiCredentialsError(RuntimeError):
+    """Indica que a integração AgroAPI não recebeu credenciais suficientes."""
+
+
+@dataclass(frozen=True)
+class AgroApiResponse:
+    """Resposta normalizada do gateway AgroAPI."""
+
+    data: Any
+    pagination: dict[str, int]
+
+
+class AgroApiTransport(Protocol):
+    """Contrato mínimo usado pelas consultas de domínio e pelos testes."""
+
+    def get(
+        self,
+        api: ApiName,
+        path: str,
+        params: dict[str, ParamValue] | None = None,
+    ) -> AgroApiResponse: ...
+
+
+class AgroApiClient:
+    """Cliente HTTP autenticado para o gateway AgroAPI da Embrapa."""
+
+    def __init__(
+        self,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        access_token: str | None = None,
+        timeout: float = _TIMEOUT,
+    ) -> None:
+        self._client_id = client_id.strip() if client_id else None
+        self._client_secret = client_secret.strip() if client_secret else None
+        self._static_token = access_token.strip() if access_token else None
+        self._timeout = timeout
+        self._cached_token: str | None = None
+        self._token_expires_at = 0.0
+        self._token_generation = 0
+        self._token_lock = Lock()
+
+    @classmethod
+    def from_env(cls) -> AgroApiClient:
+        """Cria cliente usando somente as variáveis de ambiente documentadas."""
+        return cls(
+            client_id=_first_env("AGROAPI_CLIENT_ID", "AGROAPI_CONSUMER_KEY"),
+            client_secret=_first_env("AGROAPI_CLIENT_SECRET", "AGROAPI_CONSUMER_SECRET"),
+            access_token=_first_env("AGROAPI_TOKEN", "AGROAPI_ACCESS_TOKEN"),
+        )
+
+    def _access_token(self) -> tuple[str, int]:
+        if self._static_token:
+            return self._static_token, 0
+
+        with self._token_lock:
+            agora = time.monotonic()
+            if self._cached_token and agora < self._token_expires_at:
+                return self._cached_token, self._token_generation
+
+            if not self._client_id or not self._client_secret:
+                raise AgroApiCredentialsError(
+                    "AgroAPI não configurada. Defina AGROAPI_CLIENT_ID e "
+                    "AGROAPI_CLIENT_SECRET, ou forneça AGROAPI_TOKEN."
+                )
+
+            try:
+                with httpx.Client(
+                    timeout=self._timeout,
+                    auth=(self._client_id, self._client_secret),
+                    follow_redirects=False,
+                ) as client:
+                    response = client.post(
+                        _TOKEN_URL,
+                        data={"grant_type": "client_credentials"},
+                        headers={"Accept": "application/json"},
+                    )
+                    response.raise_for_status()
+                    payload = response.json()
+            except httpx.HTTPStatusError as exc:
+                raise AgroApiCredentialsError(
+                    f"Falha ao autenticar na AgroAPI (HTTP {exc.response.status_code}). "
+                    "Confirme a assinatura das APIs e as credenciais da aplicação."
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise RuntimeError(f"Falha de rede ao autenticar na AgroAPI: {exc}") from exc
+
+            token = payload.get("access_token") if isinstance(payload, dict) else None
+            if not isinstance(token, str) or not token.strip():
+                raise AgroApiCredentialsError("A AgroAPI não retornou um access_token válido.")
+
+            expires_in_raw = payload.get("expires_in", 3600)
+            try:
+                expires_in = max(int(expires_in_raw), 1)
+            except (TypeError, ValueError):
+                expires_in = 3600
+
+            self._cached_token = token.strip()
+            self._token_generation += 1
+            margem = min(_TOKEN_EXPIRY_MARGIN_SECONDS, max(expires_in // 10, 1))
+            self._token_expires_at = agora + max(expires_in - margem, 1)
+            return self._cached_token, self._token_generation
+
+    def _invalidate_cached_token(self, rejected_generation: int) -> None:
+        """Invalida somente o token que foi efetivamente rejeitado.
+
+        A comparação da geração sob o mesmo lock impede que uma resposta 401
+        atrasada apague um token que outra chamada concorrente acabou de
+        renovar, mesmo se o emissor repetir o mesmo valor textual do token.
+        """
+        with self._token_lock:
+            if self._cached_token is not None and self._token_generation == rejected_generation:
+                self._cached_token = None
+                self._token_expires_at = 0.0
+
+    def _request(
+        self,
+        api: ApiName,
+        path: str,
+        params: dict[str, ParamValue],
+        *,
+        allow_refresh: bool,
+    ) -> httpx.Response:
+        token, token_generation = self._access_token()
+        url = f"{_API_BASE_URLS[api]}{path}"
+        try:
+            with httpx.Client(timeout=self._timeout, follow_redirects=False) as client:
+                response = client.get(
+                    url,
+                    params=params,
+                    headers={
+                        "Accept": "application/json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                )
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Falha de rede ao consultar {_API_LABELS[api]}: {exc}") from exc
+
+        if response.status_code == 401 and allow_refresh and not self._static_token:
+            self._invalidate_cached_token(token_generation)
+            return self._request(api, path, params, allow_refresh=False)
+
+        if response.status_code == 401:
+            raise AgroApiCredentialsError(
+                f"Token rejeitado por {_API_LABELS[api]}. Renove as credenciais ou o AGROAPI_TOKEN."
+            )
+
+        response.raise_for_status()
+        return response
+
+    def get(
+        self,
+        api: ApiName,
+        path: str,
+        params: dict[str, ParamValue] | None = None,
+    ) -> AgroApiResponse:
+        """Executa GET autenticado e preserva metadados de paginação."""
+        response = self._request(api, path, params or {}, allow_refresh=True)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RuntimeError(f"{_API_LABELS[api]} retornou resposta JSON inválida.") from exc
+
+        pagination: dict[str, int] = {}
+        header_map = {
+            "X-Records-Count": "total_registros",
+            "X-Pages": "total_paginas",
+            "X-Page-Size": "tamanho_pagina",
+        }
+        for header, key in header_map.items():
+            value = response.headers.get(header)
+            if value is not None:
+                try:
+                    pagination[key] = int(value)
+                except ValueError:
+                    continue
+
+        page = (params or {}).get("page")
+        if isinstance(page, int):
+            pagination["pagina"] = page
+        return AgroApiResponse(data=data, pagination=pagination)
+
+
+_DEFAULT_CLIENT: AgroApiClient | None = None
+
+
+def _first_env(*names: str) -> str | None:
+    for name in names:
+        value = os.getenv(name)
+        if value and value.strip():
+            return value
+    return None
+
+
+def is_configured() -> bool:
+    """Indica se há token ou par completo de credenciais no ambiente."""
+    if _first_env("AGROAPI_TOKEN", "AGROAPI_ACCESS_TOKEN"):
+        return True
+    client_id = _first_env("AGROAPI_CLIENT_ID", "AGROAPI_CONSUMER_KEY")
+    client_secret = _first_env("AGROAPI_CLIENT_SECRET", "AGROAPI_CONSUMER_SECRET")
+    return bool(client_id and client_secret)
+
+
+def _client(client: AgroApiTransport | None) -> AgroApiTransport:
+    global _DEFAULT_CLIENT
+    if client is not None:
+        return client
+    if _DEFAULT_CLIENT is None:
+        _DEFAULT_CLIENT = AgroApiClient.from_env()
+    return _DEFAULT_CLIENT
+
+
+def _texto(value: str) -> str:
+    return value.strip()
+
+
+def _pagina(value: int) -> int:
+    if value < 1:
+        raise ValueError("pagina deve ser maior ou igual a 1.")
+    return value
+
+
+def _resultado(
+    api: ApiName,
+    response: AgroApiResponse,
+    *,
+    aviso: str | None = None,
+) -> dict[str, Any]:
+    resultado: dict[str, Any] = {
+        "fonte": "Embrapa Agricultura Digital - AgroAPI",
+        "fonte_url": _DOC_URLS[api],
+        "api": _API_LABELS[api],
+        "resultados": response.data,
+        "data_consulta": date.today().isoformat(),
+    }
+    if response.pagination:
+        resultado["paginacao"] = response.pagination
+    if aviso:
+        resultado["aviso"] = aviso
+    return resultado
+
+
+def _resumo_produtos(data: Any) -> Any:
+    """Remove documentos extensos das buscas e mantém os campos de decisão."""
+    if not isinstance(data, list):
+        return data
+    campos = (
+        "numero_registro",
+        "marca_comercial",
+        "titular_registro",
+        "produto_biologico",
+        "classe_categoria_agronomica",
+        "formulacao",
+        "ingrediente_ativo",
+        "modo_acao",
+        "tecnica_aplicacao",
+        "classificacao_toxicologica",
+        "classificacao_ambiental",
+        "produto_agricultura_organica",
+        "url_agrofit",
+    )
+    produtos: list[Any] = []
+    for item in data:
+        if not isinstance(item, dict):
+            produtos.append(item)
+            continue
+        resumo = {key: item[key] for key in campos if key in item}
+        indicacoes = item.get("indicacao_uso")
+        if isinstance(indicacoes, list):
+            resumo["indicacoes_uso_total"] = len(indicacoes)
+        documentos = item.get("documento_cadastrado")
+        if isinstance(documentos, list):
+            resumo["documentos_total"] = len(documentos)
+        produtos.append(resumo)
+    return produtos
+
+
+def _normalizar_busca(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value)
+    return "".join(char for char in decomposed if not unicodedata.combining(char)).casefold()
+
+
+def _filtrar_envelope(data: Any, campo: str, termo: str, limite: int = 20) -> Any:
+    if not isinstance(data, dict) or not isinstance(data.get("data"), list):
+        return data
+    termo_normalizado = _normalizar_busca(termo)
+    encontrados = [
+        item
+        for item in data["data"]
+        if isinstance(item, dict)
+        and termo_normalizado in _normalizar_busca(str(item.get(campo, "")))
+    ]
+    return {
+        "meta": {
+            "totalCount": len(encontrados),
+            "totalCountFonte": data.get("meta", {}).get("totalCount")
+            if isinstance(data.get("meta"), dict)
+            else None,
+            "limiteRetornado": len(encontrados[:limite]),
+        },
+        "data": encontrados[:limite],
+    }
+
+
+def buscar_produtos_agrofit(
+    termo: str = "",
+    cultura: str = "",
+    praga: str = "",
+    ingrediente_ativo: str = "",
+    categoria: str = "",
+    produto_biologico: bool | None = None,
+    pagina: int = 1,
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Busca produtos formulados registrados na API AGROFIT."""
+    filtros: dict[str, ParamValue] = {
+        "q": _texto(termo),
+        "cultura": _texto(cultura),
+        "praga_nome_comum": _texto(praga),
+        "ingrediente_ativo": _texto(ingrediente_ativo),
+        "classe_categoria_agronomica": _texto(categoria),
+    }
+    filtros = {key: value for key, value in filtros.items() if value != ""}
+    if produto_biologico is not None:
+        filtros["produto_biologico"] = produto_biologico
+    if not filtros:
+        raise ValueError("Informe ao menos um filtro para pesquisar produtos no AGROFIT.")
+    filtros["page"] = _pagina(pagina)
+
+    response = _client(client).get("agrofit", "/search/produtos-formulados", filtros)
+    response = AgroApiResponse(
+        data=_resumo_produtos(response.data),
+        pagination=response.pagination,
+    )
+    return _resultado("agrofit", response, aviso=_AGROFIT_AVISO)
+
+
+def consultar_produto_agrofit(
+    numero_registro: str,
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Consulta o detalhe de um produto AGROFIT por número de registro."""
+    registro = _texto(numero_registro)
+    if not registro:
+        raise ValueError("numero_registro não pode ser vazio.")
+    path = f"/produtos-formulados/{quote(registro, safe='')}"
+    response = _client(client).get("agrofit", path)
+    return _resultado("agrofit", response, aviso=_AGROFIT_AVISO)
+
+
+def buscar_municipios_agritec(
+    nome: str,
+    uf: str,
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Resolve nome e UF para o código IBGE usado pela Agritec."""
+    nome_normalizado = _texto(nome)
+    if not nome_normalizado:
+        raise ValueError("nome não pode ser vazio.")
+    uf_normalizada = _texto(uf).upper()
+    if uf_normalizada not in _UFS:
+        raise ValueError("uf deve ser uma sigla válida de unidade federativa brasileira.")
+    response = _client(client).get("agritec", "/municipios", {"uf": uf_normalizada})
+    response = AgroApiResponse(
+        data=_filtrar_envelope(response.data, "nome", nome_normalizado),
+        pagination=response.pagination,
+    )
+    return _resultado("agritec", response)
+
+
+def buscar_culturas_agritec(
+    nome: str,
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Resolve nome de cultura para o identificador usado pela Agritec."""
+    nome_normalizado = _texto(nome)
+    if not nome_normalizado:
+        raise ValueError("nome não pode ser vazio.")
+    response = _client(client).get("agritec", "/culturas")
+    response = AgroApiResponse(
+        data=_filtrar_envelope(response.data, "nome", nome_normalizado),
+        pagination=response.pagination,
+    )
+    return _resultado("agritec", response)
+
+
+def consultar_zarc_agritec(
+    codigo_ibge: int,
+    id_cultura: int,
+    risco: str = "20",
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Consulta o Zoneamento Agrícola de Risco Climático na Agritec v2."""
+    if codigo_ibge <= 0:
+        raise ValueError("codigo_ibge deve ser um inteiro positivo.")
+    if id_cultura <= 0:
+        raise ValueError("id_cultura deve ser um inteiro positivo.")
+    risco_normalizado = _texto(risco).lower()
+    if risco_normalizado not in {"20", "30", "40", "todos"}:
+        raise ValueError("risco deve ser 20, 30, 40 ou 'todos'.")
+
+    response = _client(client).get(
+        "agritec",
+        "/zoneamento",
+        {
+            "codigoIBGE": codigo_ibge,
+            "idCultura": id_cultura,
+            "risco": risco_normalizado,
+        },
+    )
+    return _resultado("agritec", response, aviso=_ZARC_AVISO)
+
+
+def buscar_cultivares_agritec(
+    id_cultura: int,
+    uf: str,
+    safra: str = "2026-2027",
+    regiao: str = "",
+    grupo: str = "",
+    cultivar: str = "",
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Busca cultivares indicadas pela Agritec para cultura, UF e safra."""
+    if id_cultura <= 0:
+        raise ValueError("id_cultura deve ser um inteiro positivo.")
+    uf_normalizada = _texto(uf).upper()
+    if uf_normalizada not in _UFS:
+        raise ValueError("uf deve ser uma sigla válida de unidade federativa brasileira.")
+    safra_normalizada = _texto(safra)
+    if not re.fullmatch(r"\d{4}-\d{4}", safra_normalizada):
+        raise ValueError("safra deve usar o formato YYYY-YYYY, por exemplo 2026-2027.")
+
+    params: dict[str, ParamValue] = {
+        "idCultura": id_cultura,
+        "uf": uf_normalizada,
+        "safra": safra_normalizada,
+    }
+    regiao_normalizada = _texto(regiao)
+    if regiao_normalizada:
+        if regiao_normalizada not in {"1", "2", "3", "4", "5"}:
+            raise ValueError("regiao deve estar entre 1 e 5.")
+        params["regiao"] = regiao_normalizada
+    grupo_normalizado = _texto(grupo).upper()
+    if grupo_normalizado:
+        if grupo_normalizado not in {"I", "II", "III", "IV"}:
+            raise ValueError("grupo deve ser I, II, III ou IV.")
+        params["grupo"] = grupo_normalizado
+    cultivar_normalizada = _texto(cultivar)
+    if cultivar_normalizada:
+        params["cultivar"] = cultivar_normalizada
+
+    response = _client(client).get("agritec", "/cultivares", params)
+    return _resultado("agritec", response, aviso=_ZARC_AVISO)
+
+
+def buscar_produtos_bioinsumos(
+    tipo: str = "biologico",
+    termo: str = "",
+    cultura: str = "",
+    praga: str = "",
+    ingrediente_ativo: str = "",
+    uf: str = "",
+    especie: str = "",
+    pagina: int = 1,
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Busca produtos biológicos ou inoculantes registrados no MAPA."""
+    tipo_normalizado = _texto(tipo).lower().replace("-", "_")
+    aliases = {
+        "biologico": "biologico",
+        "biologicos": "biologico",
+        "produto_biologico": "biologico",
+        "produtos_biologicos": "biologico",
+        "inoculante": "inoculante",
+        "inoculantes": "inoculante",
+    }
+    categoria = aliases.get(tipo_normalizado)
+    if categoria is None:
+        raise ValueError("tipo deve ser 'biologico' ou 'inoculante'.")
+
+    params: dict[str, ParamValue] = {
+        "q": _texto(termo),
+        "cultura": _texto(cultura),
+    }
+    path = "/search/produtos-biologicos"
+    if categoria == "biologico":
+        params.update(
+            {
+                "praga_nome_comum": _texto(praga),
+                "ingrediente_ativo": _texto(ingrediente_ativo),
+            }
+        )
+        if _texto(uf) or _texto(especie):
+            raise ValueError("uf e especie são filtros exclusivos de inoculantes.")
+    else:
+        path = "/search/inoculantes"
+        uf_normalizada = _texto(uf).upper()
+        if uf_normalizada:
+            if uf_normalizada not in _UFS:
+                raise ValueError("uf deve ser uma sigla válida de unidade federativa brasileira.")
+            params["uf"] = uf_normalizada
+        especie_normalizada = _texto(especie)
+        if especie_normalizada:
+            params["especie"] = especie_normalizada
+        if _texto(praga) or _texto(ingrediente_ativo):
+            raise ValueError(
+                "praga e ingrediente_ativo são filtros exclusivos de produtos biológicos."
+            )
+
+    params = {key: value for key, value in params.items() if value != ""}
+    if not params:
+        raise ValueError("Informe ao menos um filtro para pesquisar bioinsumos.")
+    params["page"] = _pagina(pagina)
+
+    response = _client(client).get("bioinsumos", path, params)
+    if categoria == "biologico":
+        response = AgroApiResponse(
+            data=_resumo_produtos(response.data),
+            pagination=response.pagination,
+        )
+    resultado = _resultado("bioinsumos", response, aviso=_BIOINSUMOS_AVISO)
+    resultado["tipo_consulta"] = categoria
+    return resultado
+
+
+def buscar_termos_agrotermos(
+    termo: str,
+    incluir_relacoes: bool = False,
+    *,
+    client: AgroApiTransport | None = None,
+) -> dict[str, Any]:
+    """Busca fragmento ou, opcionalmente, relações de um termo exato no AgroTermos."""
+    termo_normalizado = _texto(termo)
+    if not termo_normalizado:
+        raise ValueError("termo não pode ser vazio.")
+    path = "/termoComRelacoes" if incluir_relacoes else "/termoParcial"
+    response = _client(client).get("agrotermos", path, {"label": termo_normalizado})
+    resultado = _resultado("agrotermos", response)
+    resultado["tipo_busca"] = (
+        "termo_exato_com_relacoes" if incluir_relacoes else "fragmento_sem_relacoes"
+    )
+    return resultado

--- a/src/mcp_agro_brasil/server.py
+++ b/src/mcp_agro_brasil/server.py
@@ -18,17 +18,24 @@ Tools expostas:
 - listar_pracas         : praças disponíveis no provider Scot
 - listar_produtos       : produtos com cotação disponível
 - listar_unidades       : unidades suportadas pelo módulo de conversão
+
+Tools AgroAPI opcionais (registradas somente com credenciais configuradas):
+- agrofit_buscar_produtos / agrofit_consultar_produto
+- agritec_buscar_municipios / agritec_buscar_culturas
+- agritec_consultar_zarc / agritec_buscar_cultivares
+- bioinsumos_buscar_produtos / agrotermos_buscar
 """
 
 from __future__ import annotations
 
 import fastmcp
 
+from mcp_agro_brasil.agroapi_tools import registrar_tools_agroapi
 from mcp_agro_brasil.core import conversao, cotacao
 
 app = fastmcp.FastMCP(
     name="MCP Agro Brasil",
-    version="0.4.0",
+    version="0.5.0",
     instructions=(
         "Ferramentas de dados do agronegócio brasileiro. "
         "Cotações de boi gordo via Scot Consultoria (regional) e ESALQ/B3 (nacional). "
@@ -324,6 +331,11 @@ def listar_unidades() -> dict[str, object]:
         "unidades_peso": conversao.UNIDADES_PESO,
         "unidades_area": conversao.UNIDADES_AREA,
     }
+
+
+# A integração autenticada não altera o conjunto padrão de tools. O bloco só é
+# registrado quando há token ou par completo de credenciais no ambiente.
+AGROAPI_ENABLED = registrar_tools_agroapi(app)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agroapi.py
+++ b/tests/test_agroapi.py
@@ -21,6 +21,8 @@ from mcp_agro_brasil.providers.agroapi import (
     consultar_zarc_agritec,
 )
 
+_CONCURRENCY_TIMEOUT_SECONDS = 10.0
+
 
 class RecordingClient:
     """Cliente mínimo para validar rotas e parâmetros sem acessar a rede."""
@@ -251,7 +253,7 @@ def test_cliente_nao_apaga_token_renovado_igual_em_401_atrasado(
                 ordem = chamadas["get"]
             if ordem == 1:
                 primeira_requisicao_iniciada.set()
-                if not token_renovado.wait(timeout=2):
+                if not token_renovado.wait(timeout=_CONCURRENCY_TIMEOUT_SECONDS):
                     raise AssertionError("A segunda chamada não renovou o token a tempo")
                 return MockResponse(401)
             if ordem == 2:
@@ -272,10 +274,10 @@ def test_cliente_nao_apaga_token_renovado_igual_em_401_atrasado(
     segunda = Thread(target=consultar, args=(client,))
 
     primeira.start()
-    assert primeira_requisicao_iniciada.wait(timeout=2)
+    assert primeira_requisicao_iniciada.wait(timeout=_CONCURRENCY_TIMEOUT_SECONDS)
     segunda.start()
-    primeira.join(timeout=2)
-    segunda.join(timeout=2)
+    primeira.join(timeout=_CONCURRENCY_TIMEOUT_SECONDS)
+    segunda.join(timeout=_CONCURRENCY_TIMEOUT_SECONDS)
 
     assert not primeira.is_alive()
     assert not segunda.is_alive()
@@ -335,7 +337,6 @@ def test_agritec_zarc_valida_risco_e_mapeia_parametros() -> None:
     resultado = consultar_zarc_agritec(
         codigo_ibge=5105259,
         id_cultura=1209,
-        risco="20",
         client=client,
     )
 
@@ -343,7 +344,7 @@ def test_agritec_zarc_valida_risco_e_mapeia_parametros() -> None:
         (
             "agritec",
             "/zoneamento",
-            {"codigoIBGE": 5105259, "idCultura": 1209, "risco": "20"},
+            {"codigoIBGE": 5105259, "idCultura": 1209, "risco": "todos"},
         )
     ]
     assert resultado["api"] == "Agritec v2"
@@ -426,6 +427,26 @@ def test_bioinsumos_seleciona_endpoint(tipo: str, esperado: str) -> None:
 
     assert client.calls[0][0] == "bioinsumos"
     assert client.calls[0][1] == esperado
+
+
+def test_bioinsumos_rejeita_filtro_de_inoculante_em_produto_biologico() -> None:
+    with pytest.raises(ValueError, match="exclusivos de inoculantes"):
+        buscar_produtos_bioinsumos(
+            tipo="biologico",
+            termo="soja",
+            uf="MT",
+            client=RecordingClient(),
+        )
+
+
+def test_bioinsumos_rejeita_filtro_biologico_em_inoculante() -> None:
+    with pytest.raises(ValueError, match="exclusivos de produtos biológicos"):
+        buscar_produtos_bioinsumos(
+            tipo="inoculante",
+            termo="soja",
+            praga="mosca branca",
+            client=RecordingClient(),
+        )
 
 
 def test_agrotermos_busca_parcial_ou_relacoes() -> None:

--- a/tests/test_agroapi.py
+++ b/tests/test_agroapi.py
@@ -1,0 +1,441 @@
+"""Testes da integração opcional com as APIs AgroAPI da Embrapa."""
+
+from __future__ import annotations
+
+from threading import Event, Lock, Thread
+from typing import Any
+
+import pytest
+
+from mcp_agro_brasil.providers.agroapi import (
+    AgroApiClient,
+    AgroApiCredentialsError,
+    AgroApiResponse,
+    buscar_cultivares_agritec,
+    buscar_culturas_agritec,
+    buscar_municipios_agritec,
+    buscar_produtos_agrofit,
+    buscar_produtos_bioinsumos,
+    buscar_termos_agrotermos,
+    consultar_produto_agrofit,
+    consultar_zarc_agritec,
+)
+
+
+class RecordingClient:
+    """Cliente mínimo para validar rotas e parâmetros sem acessar a rede."""
+
+    def __init__(self, data: Any = None) -> None:
+        self.data = [] if data is None else data
+        self.calls: list[tuple[str, str, dict[str, str | int | bool]]] = []
+
+    def get(
+        self,
+        api: str,
+        path: str,
+        params: dict[str, str | int | bool] | None = None,
+    ) -> AgroApiResponse:
+        self.calls.append((api, path, params or {}))
+        return AgroApiResponse(
+            data=self.data,
+            pagination={"pagina": 1, "total_registros": 1, "total_paginas": 1},
+        )
+
+
+def test_cliente_sem_credenciais_falha_antes_da_rede(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for nome in (
+        "AGROAPI_TOKEN",
+        "AGROAPI_ACCESS_TOKEN",
+        "AGROAPI_CLIENT_ID",
+        "AGROAPI_CONSUMER_KEY",
+        "AGROAPI_CLIENT_SECRET",
+        "AGROAPI_CONSUMER_SECRET",
+    ):
+        monkeypatch.delenv(nome, raising=False)
+
+    def fail_on_network(**kwargs: object) -> None:
+        raise AssertionError(f"A rede não deveria ser acessada: {kwargs}")
+
+    monkeypatch.setattr("httpx.Client", fail_on_network)
+
+    client = AgroApiClient.from_env()
+    with pytest.raises(AgroApiCredentialsError, match="AGROAPI_CLIENT_ID"):
+        client.get("agrofit", "/culturas")
+
+
+def test_cliente_obtem_token_uma_vez_e_reutiliza(monkeypatch: pytest.MonkeyPatch) -> None:
+    chamadas = {"token": 0, "get": 0}
+    headers_recebidos: list[dict[str, str]] = []
+
+    class MockResponse:
+        def __init__(self, data: Any, status_code: int = 200) -> None:
+            self._data = data
+            self.status_code = status_code
+            self.headers: dict[str, str] = {}
+
+        def json(self) -> Any:
+            return self._data
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class MockHttpClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> MockHttpClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def post(self, url: str, **kwargs: object) -> MockResponse:
+            chamadas["token"] += 1
+            assert url == "https://api.cnptia.embrapa.br/token"
+            assert kwargs["data"] == {"grant_type": "client_credentials"}
+            return MockResponse({"access_token": "token-de-teste", "expires_in": 3600})
+
+        def get(self, url: str, **kwargs: object) -> MockResponse:
+            chamadas["get"] += 1
+            headers = kwargs["headers"]
+            assert isinstance(headers, dict)
+            headers_recebidos.append(headers)
+            assert url == "https://api.cnptia.embrapa.br/agrofit/v1/culturas"
+            return MockResponse([{"nome": "Soja"}])
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "Client", MockHttpClient)
+    client = AgroApiClient(client_id="cliente", client_secret="segredo")
+
+    primeira = client.get("agrofit", "/culturas")
+    segunda = client.get("agrofit", "/culturas")
+
+    assert primeira.data == [{"nome": "Soja"}]
+    assert segunda.data == [{"nome": "Soja"}]
+    assert chamadas == {"token": 1, "get": 2}
+    assert all(item["Authorization"] == "Bearer token-de-teste" for item in headers_recebidos)
+
+
+def test_cliente_renova_token_uma_vez_apos_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    tokens = iter(("token-a", "token-b"))
+    statuses = iter((401, 200))
+    autorizacoes: list[str] = []
+    chamadas = {"token": 0, "get": 0}
+
+    class MockResponse:
+        def __init__(self, data: Any, status_code: int = 200) -> None:
+            self._data = data
+            self.status_code = status_code
+            self.headers: dict[str, str] = {}
+
+        def json(self) -> Any:
+            return self._data
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class MockHttpClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> MockHttpClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def post(self, url: str, **kwargs: object) -> MockResponse:
+            chamadas["token"] += 1
+            return MockResponse({"access_token": next(tokens), "expires_in": 3600})
+
+        def get(self, url: str, **kwargs: object) -> MockResponse:
+            chamadas["get"] += 1
+            headers = kwargs["headers"]
+            assert isinstance(headers, dict)
+            autorizacoes.append(headers["Authorization"])
+            return MockResponse([{"nome": "Soja"}], next(statuses))
+
+    monkeypatch.setattr("httpx.Client", MockHttpClient)
+    client = AgroApiClient(client_id="cliente", client_secret="segredo")
+
+    resultado = client.get("agrofit", "/culturas")
+
+    assert resultado.data == [{"nome": "Soja"}]
+    assert chamadas == {"token": 2, "get": 2}
+    assert autorizacoes == ["Bearer token-a", "Bearer token-b"]
+
+
+def test_cliente_nao_tenta_renovar_token_estatico_em_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chamadas = {"post": 0, "get": 0}
+
+    class MockResponse:
+        def __init__(self) -> None:
+            self.status_code = 401
+            self.headers: dict[str, str] = {}
+
+    class MockHttpClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> MockHttpClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def post(self, url: str, **kwargs: object) -> MockResponse:
+            chamadas["post"] += 1
+            return MockResponse()
+
+        def get(self, url: str, **kwargs: object) -> MockResponse:
+            chamadas["get"] += 1
+            return MockResponse()
+
+    monkeypatch.setattr("httpx.Client", MockHttpClient)
+    client = AgroApiClient(access_token="token-estatico")
+
+    with pytest.raises(AgroApiCredentialsError, match="Token rejeitado"):
+        client.get("agrofit", "/culturas")
+
+    assert chamadas == {"post": 0, "get": 1}
+
+
+def test_cliente_nao_apaga_token_renovado_igual_em_401_atrasado(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primeira_requisicao_iniciada = Event()
+    token_renovado = Event()
+    contador_lock = Lock()
+    chamadas = {"token": 0, "get": 0}
+    resultados: list[AgroApiResponse] = []
+    erros: list[BaseException] = []
+
+    class MockResponse:
+        def __init__(self, status_code: int, data: Any = None) -> None:
+            self.status_code = status_code
+            self._data = [{"nome": "Soja"}] if data is None else data
+            self.headers: dict[str, str] = {}
+
+        def json(self) -> Any:
+            return self._data
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class MockHttpClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> MockHttpClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def post(self, url: str, **kwargs: object) -> MockResponse:
+            with contador_lock:
+                chamadas["token"] += 1
+            return MockResponse(
+                200,
+                {"access_token": "token-repetido", "expires_in": 3600},
+            )
+
+        def get(self, url: str, **kwargs: object) -> MockResponse:
+            with contador_lock:
+                chamadas["get"] += 1
+                ordem = chamadas["get"]
+            if ordem == 1:
+                primeira_requisicao_iniciada.set()
+                if not token_renovado.wait(timeout=2):
+                    raise AssertionError("A segunda chamada não renovou o token a tempo")
+                return MockResponse(401)
+            if ordem == 2:
+                return MockResponse(401)
+            if ordem == 3:
+                token_renovado.set()
+            return MockResponse(200)
+
+    def consultar(client: AgroApiClient) -> None:
+        try:
+            resultados.append(client.get("agrofit", "/culturas"))
+        except BaseException as exc:
+            erros.append(exc)
+
+    monkeypatch.setattr("httpx.Client", MockHttpClient)
+    client = AgroApiClient(client_id="cliente", client_secret="segredo")
+    primeira = Thread(target=consultar, args=(client,))
+    segunda = Thread(target=consultar, args=(client,))
+
+    primeira.start()
+    assert primeira_requisicao_iniciada.wait(timeout=2)
+    segunda.start()
+    primeira.join(timeout=2)
+    segunda.join(timeout=2)
+
+    assert not primeira.is_alive()
+    assert not segunda.is_alive()
+    assert erros == []
+    assert len(resultados) == 2
+    assert chamadas == {"token": 2, "get": 4}
+
+
+def test_agrofit_busca_mapeia_filtros_oficiais() -> None:
+    client = RecordingClient()
+
+    resultado = buscar_produtos_agrofit(
+        termo="mosca branca",
+        cultura="Soja",
+        praga="Mosca branca",
+        ingrediente_ativo="beauveria",
+        categoria="Inseticida Microbiológico",
+        produto_biologico=True,
+        pagina=2,
+        client=client,
+    )
+
+    assert client.calls == [
+        (
+            "agrofit",
+            "/search/produtos-formulados",
+            {
+                "q": "mosca branca",
+                "cultura": "Soja",
+                "praga_nome_comum": "Mosca branca",
+                "ingrediente_ativo": "beauveria",
+                "classe_categoria_agronomica": "Inseticida Microbiológico",
+                "produto_biologico": True,
+                "page": 2,
+            },
+        )
+    ]
+    assert resultado["api"] == "AGROFIT v1"
+    assert "prescrição" in str(resultado["aviso"]).lower()
+
+
+def test_agrofit_exige_filtro_para_evitar_consulta_ampla() -> None:
+    with pytest.raises(ValueError, match="filtro"):
+        buscar_produtos_agrofit(client=RecordingClient())
+
+
+def test_agrofit_consulta_produto_por_registro() -> None:
+    client = RecordingClient(data=[{"numero_registro": "5810"}])
+    resultado = consultar_produto_agrofit("5810", client=client)
+
+    assert client.calls == [("agrofit", "/produtos-formulados/5810", {})]
+    assert resultado["resultados"] == [{"numero_registro": "5810"}]
+
+
+def test_agritec_zarc_valida_risco_e_mapeia_parametros() -> None:
+    client = RecordingClient()
+    resultado = consultar_zarc_agritec(
+        codigo_ibge=5105259,
+        id_cultura=1209,
+        risco="20",
+        client=client,
+    )
+
+    assert client.calls == [
+        (
+            "agritec",
+            "/zoneamento",
+            {"codigoIBGE": 5105259, "idCultura": 1209, "risco": "20"},
+        )
+    ]
+    assert resultado["api"] == "Agritec v2"
+
+    with pytest.raises(ValueError, match="risco"):
+        consultar_zarc_agritec(5105259, 1209, risco="50", client=client)
+
+
+def test_agritec_cultivares_mapeia_filtros() -> None:
+    client = RecordingClient()
+    buscar_cultivares_agritec(
+        id_cultura=1209,
+        uf="mt",
+        safra="2026-2027",
+        grupo="II",
+        cultivar="BRS",
+        client=client,
+    )
+
+    assert client.calls == [
+        (
+            "agritec",
+            "/cultivares",
+            {
+                "idCultura": 1209,
+                "uf": "MT",
+                "safra": "2026-2027",
+                "grupo": "II",
+                "cultivar": "BRS",
+            },
+        )
+    ]
+
+
+def test_agritec_resolve_municipio_e_cultura_sem_acentos() -> None:
+    municipios = RecordingClient(
+        data={
+            "meta": {"totalCount": 2},
+            "data": [
+                {"codigoIBGE": 5105259, "nome": "LUCAS DO RIO VERDE", "uf": "MT"},
+                {"codigoIBGE": 5107909, "nome": "SINOP", "uf": "MT"},
+            ],
+        }
+    )
+    culturas = RecordingClient(
+        data={
+            "meta": {"totalCount": 2},
+            "data": [
+                {"id": 1209, "nome": "SOJA SEQUEIRO"},
+                {"id": 6060, "nome": "SOJA - NÍVEIS DE MANEJO"},
+            ],
+        }
+    )
+
+    resultado_municipio = buscar_municipios_agritec("lucas do rio verde", "mt", client=municipios)
+    resultado_cultura = buscar_culturas_agritec("niveis de manejo", client=culturas)
+
+    assert municipios.calls == [("agritec", "/municipios", {"uf": "MT"})]
+    assert resultado_municipio["resultados"]["data"][0]["codigoIBGE"] == 5105259
+    assert resultado_municipio["resultados"]["meta"]["limiteRetornado"] == 1
+    assert culturas.calls == [("agritec", "/culturas", {})]
+    assert resultado_cultura["resultados"]["data"][0]["id"] == 6060
+
+
+@pytest.mark.parametrize(
+    ("tipo", "esperado"),
+    [
+        ("biologico", "/search/produtos-biologicos"),
+        ("inoculante", "/search/inoculantes"),
+    ],
+)
+def test_bioinsumos_seleciona_endpoint(tipo: str, esperado: str) -> None:
+    client = RecordingClient()
+    buscar_produtos_bioinsumos(
+        tipo=tipo,
+        termo="soja",
+        cultura="Soja",
+        client=client,
+    )
+
+    assert client.calls[0][0] == "bioinsumos"
+    assert client.calls[0][1] == esperado
+
+
+def test_agrotermos_busca_parcial_ou_relacoes() -> None:
+    client = RecordingClient()
+    parcial = buscar_termos_agrotermos("soj", client=client)
+    relacoes = buscar_termos_agrotermos("soja", incluir_relacoes=True, client=client)
+
+    assert client.calls == [
+        ("agrotermos", "/termoParcial", {"label": "soj"}),
+        ("agrotermos", "/termoComRelacoes", {"label": "soja"}),
+    ]
+    assert parcial["tipo_busca"] == "fragmento_sem_relacoes"
+    assert relacoes["tipo_busca"] == "termo_exato_com_relacoes"

--- a/tests/test_agroapi_tools.py
+++ b/tests/test_agroapi_tools.py
@@ -1,0 +1,38 @@
+"""Testes do registro condicional das tools AgroAPI."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from mcp_agro_brasil.agroapi_tools import registrar_tools_agroapi
+
+
+class FakeApp:
+    def __init__(self) -> None:
+        self.tools: list[str] = []
+
+    def tool(self, fn: Callable[..., Any]) -> Callable[..., Any]:
+        self.tools.append(fn.__name__)
+        return fn
+
+
+def test_sem_configuracao_nao_registra_tools() -> None:
+    app = FakeApp()
+    assert registrar_tools_agroapi(app, enabled=False) is False
+    assert app.tools == []
+
+
+def test_com_configuracao_registra_primeira_onda_completa() -> None:
+    app = FakeApp()
+    assert registrar_tools_agroapi(app, enabled=True) is True
+    assert app.tools == [
+        "agrofit_buscar_produtos",
+        "agrofit_consultar_produto",
+        "agritec_buscar_municipios",
+        "agritec_buscar_culturas",
+        "agritec_consultar_zarc",
+        "agritec_buscar_cultivares",
+        "bioinsumos_buscar_produtos",
+        "agrotermos_buscar",
+    ]

--- a/tests/test_agroapi_tools.py
+++ b/tests/test_agroapi_tools.py
@@ -5,7 +5,28 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+import pytest
+
 from mcp_agro_brasil.agroapi_tools import registrar_tools_agroapi
+
+_AGROAPI_ENV_NAMES = (
+    "AGROAPI_TOKEN",
+    "AGROAPI_ACCESS_TOKEN",
+    "AGROAPI_CLIENT_ID",
+    "AGROAPI_CONSUMER_KEY",
+    "AGROAPI_CLIENT_SECRET",
+    "AGROAPI_CONSUMER_SECRET",
+)
+_EXPECTED_TOOLS = [
+    "agrofit_buscar_produtos",
+    "agrofit_consultar_produto",
+    "agritec_buscar_municipios",
+    "agritec_buscar_culturas",
+    "agritec_consultar_zarc",
+    "agritec_buscar_cultivares",
+    "bioinsumos_buscar_produtos",
+    "agrotermos_buscar",
+]
 
 
 class FakeApp:
@@ -26,13 +47,28 @@ def test_sem_configuracao_nao_registra_tools() -> None:
 def test_com_configuracao_registra_primeira_onda_completa() -> None:
     app = FakeApp()
     assert registrar_tools_agroapi(app, enabled=True) is True
-    assert app.tools == [
-        "agrofit_buscar_produtos",
-        "agrofit_consultar_produto",
-        "agritec_buscar_municipios",
-        "agritec_buscar_culturas",
-        "agritec_consultar_zarc",
-        "agritec_buscar_cultivares",
-        "bioinsumos_buscar_produtos",
-        "agrotermos_buscar",
-    ]
+    assert app.tools == _EXPECTED_TOOLS
+
+
+def test_decisao_automatica_sem_configuracao(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for nome in _AGROAPI_ENV_NAMES:
+        monkeypatch.delenv(nome, raising=False)
+    app = FakeApp()
+
+    assert registrar_tools_agroapi(app) is False
+    assert app.tools == []
+
+
+def test_decisao_automatica_com_credenciais_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for nome in _AGROAPI_ENV_NAMES:
+        monkeypatch.delenv(nome, raising=False)
+    monkeypatch.setenv("AGROAPI_CLIENT_ID", "cliente")
+    monkeypatch.setenv("AGROAPI_CLIENT_SECRET", "segredo")
+    app = FakeApp()
+
+    assert registrar_tools_agroapi(app) is True
+    assert app.tools == _EXPECTED_TOOLS


### PR DESCRIPTION
Closes #4

## O que muda

- adiciona cliente opcional OAuth 2.0 `client_credentials` para a AgroAPI da Embrapa;
- integra AGROFIT v1, Agritec v2, Bioinsumos v2 e AgroTermos v1;
- expõe 8 tools MCP, incluindo resolutores de município e cultura para as consultas Agritec;
- mantém as 15 tools atuais quando não há credenciais e registra 23 quando a AgroAPI está configurada;
- documenta configuração, aliases de variáveis, limitações e fontes oficiais;
- prepara a versão `0.5.0`.

## Por quê

Atender a primeira onda proposta na issue #4 com dados oficiais da Embrapa, preservando o funcionamento atual para instalações sem credenciais AgroAPI.

## Segurança e resiliência

- origens e versões das APIs são fixas, sem URL controlada pelo usuário;
- redirecionamentos HTTP ficam desabilitados;
- credenciais e tokens permanecem apenas em variáveis de ambiente/memória;
- token OAuth é armazenado com expiração e geração própria;
- em 401, a chamada renova e repete apenas uma vez no fluxo OAuth;
- tokens estáticos não são renovados automaticamente;
- o controle por geração evita que um 401 concorrente apague um token recém-renovado, inclusive quando o valor textual se repete;
- buscas amplas exigem ao menos um filtro e retornos de produtos são resumidos.

## Validação

- `169 passed` localmente;
- CI Python 3.11 e 3.12: aprovada no commit `a494f2f`;
- `ruff check` e `ruff format --check`: aprovados;
- `mypy` nos módulos e testes AgroAPI: aprovado;
- `uv build` + `twine check`: wheel e sdist aprovados;
- catálogo FastMCP: 15 tools sem credenciais e 23 com configuração AgroAPI;
- revisões independentes de código e segurança: aprovadas, sem achados abertos;
- comentário acionável do CodeRabbit corrigido e thread marcado como resolvido pelo bot.

## Cobertura pendente

Não foi possível executar o fluxo autenticado contra produção porque o ambiente não possui credenciais nem assinatura das quatro APIs. O cliente, a autenticação e as respostas foram cobertos por testes simulados; o E2E autenticado permanece como cobertura operacional futura.

O `mypy src` completo ainda aponta 4 erros preexistentes em arquivos não alterados por este PR.

## Fontes oficiais

- [Catálogo AgroAPI](https://www.portal.agroapi.cnptia.embrapa.br/catalogo-de-apis)
- [Guia de autenticação](https://www.agroapi.cnptia.embrapa.br/portal/assets/docs/agroapi-primeiros-passos.pdf)
- [AGROFIT](https://www.portal.agroapi.cnptia.embrapa.br/api-docs/agrofit)
- [Agritec](https://www.portal.agroapi.cnptia.embrapa.br/api-docs/agritec)
- [Bioinsumos](https://www.portal.agroapi.cnptia.embrapa.br/api-docs/bioinsumos)
- [AgroTermos](https://www.portal.agroapi.cnptia.embrapa.br/api-docs/agrotermos)
